### PR TITLE
fix crash on Android 5.0 API 21.

### DIFF
--- a/Legend/legendCore/src/main/java/com/lody/legend/art/ArtMethod.java
+++ b/Legend/legendCore/src/main/java/com/lody/legend/art/ArtMethod.java
@@ -50,7 +50,8 @@ public abstract class ArtMethod extends Struct {
                     ? new ArtMethodStructV23_64Bit(method)
                     : new ArtMethodStructV23(method);
         }
-        else if (Build.VERSION.SDK_INT >= 21) {
+        // The artmethod struct of Android 5.0 equals to V19,so it should not use V22.
+        else if (Build.VERSION.SDK_INT > 21) {
             return Runtime.is64Bit()
                     ? new ArtMethodStructV22_64Bit(method)
                     : new ArtMethodStructV22(method);


### PR DESCRIPTION
5.0上直接crash.  应用使用V19而不是V22.
